### PR TITLE
Don't use transactions unless there are multiple documents to persist together

### DIFF
--- a/lib/document/modifier.js
+++ b/lib/document/modifier.js
@@ -84,6 +84,11 @@ Wrapper.prototype.getChanges = function () {
   return clone(this.changes);
 };
 
+Wrapper.prototype.hasChanges = function () {
+  if (!this.persisted) return true;
+  return Object.keys(this.changes).length > 0;
+}
+
 Wrapper.prototype.didApplyChanges = function (fieldValues, relationValues) {
   var fields = this.fields;
   var relations = this.relations;

--- a/lib/repository/sequelize.js
+++ b/lib/repository/sequelize.js
@@ -212,30 +212,50 @@ function getSequelizeTransaction(transaction) {
   if (transaction && transaction.sql) return transaction.sql;
 }
 
+/**
+ * Count how many SQL queries will be required to persist this document and its children.
+ * @param  {SequelizeRepository} repo
+ * @param  {Document} document
+ * @return {Number} - 0 = none, 1 = one, 2 = many
+ */
+function countChangesToPersist(repo, document) {
+  var modifier = documentModifier(document);
+  var n = modifier.hasChanges() ? 1 : 0;
+  repo.schema.relations.some(function (relation) {
+    var val = modifier.relations[relation.name];
+    if (Array.isArray(val)) {
+      val.some(function (subval) {
+        n += countChangesToPersist(relation.target, subval);
+        if (n > 1) return true;
+      });
+    } else {
+      n += countChangesToPersist(relation.target, val);
+    }
+    if (n > 1) return true;
+  });
+  return n;
+}
+
 var superPersist = SequelizeRepository.prototype.persist;
+
 SequelizeRepository.prototype.persist = function (document, options, parent, parentRepo, parentRelation) {
   options = options || {};
-  var transaction = options.transaction;
-  if (transaction) return superPersist.apply(this, arguments);
-  var modifier = documentModifier(document);
-  var needsTransaction = this.schema.relations.some(function (relation) {
-    var val = modifier.relations[relation.name];
-    if (Array.isArray(val)) return val.length;
-    return !!val;
-  });
+  if (options.transaction) return superPersist.apply(this, arguments);
+
+  var needsTransaction = countChangesToPersist(this, document) > 1;
   if (!needsTransaction) return superPersist.apply(this, arguments);
 
   // Wrap .persist() in a transaction:
   var repo = this;
   var sequelize = $private(this).sequelize;
-  transaction = new Transaction();
-  return Promise.resolve()
-  .then(function () {
-    return sequelize.transaction(function (t) {
-      transaction.sql = t;
-      return superPersist.call(repo, document, {transaction: transaction}, parent, parentRepo, parentRelation);
-    });
+
+  var pWrapped = sequelize.transaction(function (t) {
+    var transaction = new Transaction();
+    transaction.sql = t;
+    return superPersist.call(repo, document, {transaction: transaction}, parent, parentRepo, parentRelation);
   });
+
+  return Promise.resolve(pWrapped);
 };
 
 SequelizeRepository.prototype.insert = function (changes, options, parent, parentRepo, parentRelation) {

--- a/lib/repository/sequelize.js
+++ b/lib/repository/sequelize.js
@@ -228,7 +228,7 @@ function countChangesToPersist(repo, document) {
         n += countChangesToPersist(relation.target, subval);
         if (n > 1) return true;
       });
-    } else {
+    } else if (val) {
       n += countChangesToPersist(relation.target, val);
     }
     if (n > 1) return true;


### PR DESCRIPTION
.persist() calls will still be atomic, but they won’t always need a
transaction. This makes the logs simpler, and is probably more
performant.
